### PR TITLE
Update intel-mkl-src version to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.3"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.5"
+version = "0.8"
 optional = true
 
 [dependencies.netlib-src]


### PR DESCRIPTION
`intel-mkl-src` is currently at version 0.8.1 (https://crates.io/crates/intel-mkl-src) 