### PR TITLE
Expose MKL linkage, fixes segfaults with `lapack` crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.12.0 (September 23, 2025)
+
+* `netlib-src` updated to version 0.9.0.
+
 ## Version 0.11.0 (February 8, 2025)
 
 * `r-src` updated to version 0.2.1.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lapack-src"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = [
@@ -23,10 +23,23 @@ keywords = ["linear-algebra"]
 changelog = "CHANGELOG.md"
 
 [features]
+# apple accelerate
 accelerate = ["accelerate-src"]
-intel-mkl = ["intel-mkl-src"]
+# intel mkl with different configurations
+intel-mkl = ["intel-mkl-static-lp64-seq"]
+intel-mkl-static-lp64-iomp   = ["intel-mkl-src/mkl-static-lp64-iomp"]
+intel-mkl-static-lp64-seq    = ["intel-mkl-src/mkl-static-lp64-seq"]
+intel-mkl-static-ilp64-iomp  = ["intel-mkl-src/mkl-static-ilp64-iomp"]
+intel-mkl-static-ilp64-seq   = ["intel-mkl-src/mkl-static-ilp64-seq"]
+intel-mkl-dynamic-lp64-iomp  = ["intel-mkl-src/mkl-dynamic-lp64-iomp"]
+intel-mkl-dynamic-lp64-seq   = ["intel-mkl-src/mkl-dynamic-lp64-seq"]
+intel-mkl-dynamic-ilp64-iomp = ["intel-mkl-src/mkl-dynamic-ilp64-iomp"]
+intel-mkl-dynamic-ilp64-seq  = ["intel-mkl-src/mkl-dynamic-ilp64-seq"]
+# netlib
 netlib = ["netlib-src"]
+# openblas
 openblas = ["openblas-src"]
+# R
 r = ["r-src"]
 
 [dependencies.accelerate-src]
@@ -36,6 +49,8 @@ optional = true
 [dependencies.intel-mkl-src]
 version = "0.8"
 optional = true
+default-features = false
+
 
 [dependencies.netlib-src]
 version = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,11 @@ keywords = ["linear-algebra"]
 changelog = "CHANGELOG.md"
 
 [features]
-# apple accelerate
 accelerate = ["accelerate-src"]
-# parallel LP64 version of MKL
 intel-mkl = ["intel-mkl-src/mkl-static-lp64-iomp"]
-# sequential LP64 version of MKL
 intel-mkl-seq = ["intel-mkl-src/mkl-static-lp64-seq"]
-
-# netlib
 netlib = ["netlib-src"]
-# openblas
 openblas = ["openblas-src"]
-# R
 r = ["r-src"]
 
 [dependencies.accelerate-src]
@@ -44,8 +37,6 @@ optional = true
 [dependencies.intel-mkl-src]
 version = "0.8"
 optional = true
-default-features = false
-
 
 [dependencies.netlib-src]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,11 @@ changelog = "CHANGELOG.md"
 [features]
 # apple accelerate
 accelerate = ["accelerate-src"]
-# intel mkl with different configurations
-intel-mkl = ["intel-mkl-static-lp64-seq"]
-intel-mkl-static-lp64-iomp   = ["intel-mkl-src/mkl-static-lp64-iomp"]
-intel-mkl-static-lp64-seq    = ["intel-mkl-src/mkl-static-lp64-seq"]
-intel-mkl-static-ilp64-iomp  = ["intel-mkl-src/mkl-static-ilp64-iomp"]
-intel-mkl-static-ilp64-seq   = ["intel-mkl-src/mkl-static-ilp64-seq"]
-intel-mkl-dynamic-lp64-iomp  = ["intel-mkl-src/mkl-dynamic-lp64-iomp"]
-intel-mkl-dynamic-lp64-seq   = ["intel-mkl-src/mkl-dynamic-lp64-seq"]
-intel-mkl-dynamic-ilp64-iomp = ["intel-mkl-src/mkl-dynamic-ilp64-iomp"]
-intel-mkl-dynamic-ilp64-seq  = ["intel-mkl-src/mkl-dynamic-ilp64-seq"]
+# parallel LP64 version of MKL
+intel-mkl = ["intel-mkl-src/mkl-static-lp64-iomp"]
+# sequential LP64 version of MKL
+intel-mkl-seq = ["intel-mkl-src/mkl-static-lp64-seq"]
+
 # netlib
 netlib = ["netlib-src"]
 # openblas

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lapack-src"
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = [
     "Balasubramanian Narasimhan <b.naras@gmail.com>",
@@ -48,7 +48,7 @@ default-features = false
 
 
 [dependencies.netlib-src]
-version = "0.8"
+version = "0.9"
 optional = true
 
 [dependencies.openblas-src]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lapack-src"
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = [
     "Balasubramanian Narasimhan <b.naras@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lapack-src"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = [
@@ -24,8 +24,10 @@ changelog = "CHANGELOG.md"
 
 [features]
 accelerate = ["accelerate-src"]
-intel-mkl = ["intel-mkl-src/mkl-static-lp64-iomp"]
-intel-mkl-seq = ["intel-mkl-src/mkl-static-lp64-seq"]
+intel-mkl-dynamic-parallel = ["intel-mkl-src/mkl-dynamic-lp64-iomp"]
+intel-mkl-dynamic-sequential = ["intel-mkl-src/mkl-dynamic-lp64-seq"]
+intel-mkl-static-parallel = ["intel-mkl-src/mkl-static-lp64-iomp"]
+intel-mkl-static-sequential = ["intel-mkl-src/mkl-static-lp64-seq"]
 netlib = ["netlib-src"]
 openblas = ["openblas-src"]
 r = ["r-src"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lapack-src"
 version = "0.12.0"
-edition = "2024"
+edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = [
     "Balasubramanian Narasimhan <b.naras@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ lapack-src = { version = "0.11", features = ["openblas"] }
 lapack-src = { version = "0.11", features = ["r"] }
 ```
 
+### Intel MKL Configuration
+
+The `intel-mkl` feature will *statically* link the *sequential LP64* version of
+the MKL library. To link other versions of the library, check the `intel-mkl-*-*-*`
+features inside this crate, which are analogous to the feature flags of
+the [`intel-mkl-src` crate] (https://crates.io/crates/intel-mkl-src).
+
 ## Contribution
 
 Your contribution is highly appreciated. Do not hesitate to open an issue or a

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ An implementation can be chosen as follows:
 
 ```toml
 [dependencies]
-lapack-src = { version = "0.11", features = ["accelerate"] }
-lapack-src = { version = "0.11", features = ["intel-mkl"] }
-lapack-src = { version = "0.11", features = ["netlib"] }
-lapack-src = { version = "0.11", features = ["openblas"] }
-lapack-src = { version = "0.11", features = ["r"] }
+lapack-src = { version = "0.12", features = ["accelerate"] }
+lapack-src = { version = "0.12", features = ["intel-mkl"] }
+lapack-src = { version = "0.12", features = ["netlib"] }
+lapack-src = { version = "0.12", features = ["openblas"] }
+lapack-src = { version = "0.12", features = ["r"] }
 ```
 
 ### Intel MKL Configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,17 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
 
-#[cfg(feature = "intel-mkl")]
+#[cfg(any(
+    feature = "intel-mkl",
+    feature = "intel-mkl-static-lp64-iomp",
+    feature = "intel-mkl-static-lp64-seq",
+    feature = "intel-mkl-static-ilp64-iomp",
+    feature = "intel-mkl-static-ilp64-seq",
+    feature = "intel-mkl-dynamic-lp64-iomp",
+    feature = "intel-mkl-dynamic-lp64-seq",
+    feature = "intel-mkl-dynamic-ilp64-iomp",
+    feature = "intel-mkl-dynamic-ilp64-seq"
+))]
 extern crate intel_mkl_src as raw;
 
 #[cfg(feature = "netlib")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
 
-#[cfg(any(feature = "intel-mkl", feature = "intel-mkl-seq",))]
+#[cfg(any(feature = "intel-mkl", feature = "intel-mkl-seq"))]
 extern crate intel_mkl_src as raw;
 
 #[cfg(feature = "netlib")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,21 @@
 //!
 //! ```toml
 //! [dependencies]
-//! lapack-src = { version = "0.11", features = ["accelerate"] }
-//! lapack-src = { version = "0.11", features = ["intel-mkl"] }
-//! lapack-src = { version = "0.11", features = ["netlib"] }
-//! lapack-src = { version = "0.11", features = ["openblas"] }
-//! lapack-src = { version = "0.11", features = ["r"] }
+//! lapack-src = { version = "0.12", features = ["accelerate"] }
+//! lapack-src = { version = "0.12", features = ["intel-mkl"] }
+//! lapack-src = { version = "0.12", features = ["netlib"] }
+//! lapack-src = { version = "0.12", features = ["openblas"] }
+//! lapack-src = { version = "0.12", features = ["r"] }
 //! ```
+//! ### Configuring MKL
+//!
+//! When the `intel-mkl` feature is selected, then the parallel version of
+//! MKL using OpenMP is _statically_ linked. To link the sequential version
+//! use the `intel-mkl-seq` feature. In both cases, the
+//! [LP64 interface](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2023-0/using-the-ilp64-interface-vs-lp64-interface.html)
+//! is linked. If other linkage options for MKL are desired, omit `lapack-src`
+//! as a dependency and use the [`intel-mkl-src`](https://crates.io/crates/intel-mkl-src)
+//! crate directly with the appropriate feature flags.
 //!
 //! [architecture]: https://blas-lapack-rs.github.io/architecture
 //! [lapack]: https://en.wikipedia.org/wiki/LAPACK
@@ -37,17 +46,7 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
 
-#[cfg(any(
-    feature = "intel-mkl",
-    feature = "intel-mkl-static-lp64-iomp",
-    feature = "intel-mkl-static-lp64-seq",
-    feature = "intel-mkl-static-ilp64-iomp",
-    feature = "intel-mkl-static-ilp64-seq",
-    feature = "intel-mkl-dynamic-lp64-iomp",
-    feature = "intel-mkl-dynamic-lp64-seq",
-    feature = "intel-mkl-dynamic-ilp64-iomp",
-    feature = "intel-mkl-dynamic-ilp64-seq"
-))]
+#[cfg(any(feature = "intel-mkl", feature = "intel-mkl-seq",))]
 extern crate intel_mkl_src as raw;
 
 #[cfg(feature = "netlib")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,11 @@
 //! The following implementations are available:
 //!
 //! * `accelerate`, which is the one in the [Accelerate] framework (macOS only),
-//! * `intel-mkl`, which is the one in [Intel MKL],
+//! * `intel-mkl-*`, which is the one in [Intel MKL], where
+//!   * `intel-mkl-dynamic-parallel` dynamically links the parallel backend of MKL
+//!   * `intel-mkl-dynamic-sequential` dynamically links the sequential backend of MKL
+//!   * `intel-mkl-static-parallel` statically links the parallel backend of MKL
+//!   * `intel-mkl-static-sequential` statically links the sequential backend of MKL
 //! * `netlib`, which is the reference one by [Netlib],
 //! * `openblas`, which is the one in [OpenBLAS], and
 //! * `r`, which is the one in [R].
@@ -22,15 +26,6 @@
 //! lapack-src = { version = "0.12", features = ["openblas"] }
 //! lapack-src = { version = "0.12", features = ["r"] }
 //! ```
-//! ### Configuring MKL
-//!
-//! When the `intel-mkl` feature is selected, then the parallel version of
-//! MKL using OpenMP is _statically_ linked. To link the sequential version
-//! use the `intel-mkl-seq` feature. In both cases, the
-//! [LP64 interface](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2023-0/using-the-ilp64-interface-vs-lp64-interface.html)
-//! is linked. If other linkage options for MKL are desired, omit `lapack-src`
-//! as a dependency and use the [`intel-mkl-src`](https://crates.io/crates/intel-mkl-src)
-//! crate directly with the appropriate feature flags.
 //!
 //! [architecture]: https://blas-lapack-rs.github.io/architecture
 //! [lapack]: https://en.wikipedia.org/wiki/LAPACK
@@ -46,7 +41,12 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
 
-#[cfg(any(feature = "intel-mkl", feature = "intel-mkl-seq"))]
+#[cfg(any(
+    feature = "intel-mkl-dynamic-parallel",
+    feature = "intel-mkl-dynamic-sequential",
+    feature = "intel-mkl-static-parallel",
+    feature = "intel-mkl-static-sequential",
+))]
 extern crate intel_mkl_src as raw;
 
 #[cfg(feature = "netlib")]


### PR DESCRIPTION
Hi, I've tried using the `lapack` and `lapack-src` crates like this and ran into segmentation faults and/or runtime parameter errors from the LAPACK backend. It didn't take too long to figure out that this was caused by the `intel-mkl-src` crate linking the `ILP64` version (long and int are 64-bit) of MKL, whereas the `lapack` crate exposes the `LP64` interface (long is 64 bit, int is 32 bit). So using `lapack` and `lapack-src` like this

```toml
lapack = "0.20"
lapack-src = { version = "0.11", features = ["intel-mkl"] }
```
**will produce segfaults and lapack runtime errors**. So I made two changes

## Changes

1. **BREAKING** Make the sequential `LP64` version linked when the `intel-mkl` feature is selected, so that this works together with the `lapack` crate more out of the box. This is a breaking change, but I do think it's justified for the out-of-the-box compatibility with the `lapack` crate.
2. Expose a set of features `intel-mkl-*-*-*` to allow a user to select the desired linkage.